### PR TITLE
Typo in Group link

### DIFF
--- a/docs/elements/pack.md
+++ b/docs/elements/pack.md
@@ -50,7 +50,7 @@
 | code  | String |  |
 | category  | String | personal, other |
 | image | String | cover image filename |
-| group | [Group](gruop.md) |  |
+| group | [Group](group.md) |  |
 | asset | [Asset](asset.md) |  |
 
 


### PR DESCRIPTION
Just fixing a little link typo in the help doc for Packs.